### PR TITLE
Switch to IComparable<T> to prevent boxing.

### DIFF
--- a/src/FibonacciHeap/FibonacciHeap.cs
+++ b/src/FibonacciHeap/FibonacciHeap.cs
@@ -8,7 +8,7 @@
     /// </summary>
     /// <typeparam name="T">Type of the stored objects.</typeparam>
     /// <typeparam name="TKey">Type of the object key. Should implement IComparable.</typeparam>
-    public class FibonacciHeap<T, TKey> where TKey : IComparable
+    public class FibonacciHeap<T, TKey> where TKey : IComparable<TKey>
     {
         /// <summary>
         /// Maximum nodes quantity in the heap.

--- a/src/FibonacciHeap/FibonacciHeapNode.cs
+++ b/src/FibonacciHeap/FibonacciHeapNode.cs
@@ -1,12 +1,14 @@
-﻿namespace FibonacciHeap
+﻿using System;
+
+namespace FibonacciHeap
 {
     /// <summary>
     /// Represents the one node in the Fibonacci Heap.
     /// </summary>
     /// <typeparam name="T">Type of the object to be stored.</typeparam>
     /// <typeparam name="TKey">Type of the key to be used for the stored object. 
-    /// Has to implement the <see cref="System.IComparable"/> interface.</typeparam>
-    public class FibonacciHeapNode<T, TKey> where TKey: System.IComparable
+    /// Has to implement the <see cref="IComparable"/> interface.</typeparam>
+    public class FibonacciHeapNode<T, TKey> where TKey: IComparable<TKey>
     {
         public FibonacciHeapNode(T data, TKey key)
         {


### PR DESCRIPTION
Fixes #4.